### PR TITLE
Updates to the codebase. Now it is compiling with c++17 and clang-10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(root-migrate)
 
 option(travis_build "Used for building with travis" OFF)
 
-set (CMAKE_CXX_STANDARD 11)
+set (CMAKE_CXX_STANDARD 17)
 
 find_package(LLVM REQUIRED)
 find_package(Clang REQUIRED)

--- a/main.cpp
+++ b/main.cpp
@@ -36,8 +36,9 @@ public :
      std::string NodeName = node.first;
      std::string Code;
      if (const Stmt *FS = Result.Nodes.getNodeAs<clang::Stmt>(NodeName)) {
-       const char* start = SourceMgr->getCharacterData(FS->getLocStart());
-       const char* end = SourceMgr->getCharacterData(FS->getLocEnd());
+
+       const char* start = SourceMgr->getCharacterData(FS->getBeginLoc());
+       const char* end = SourceMgr->getCharacterData(FS->getEndLoc());
        Code = std::string(start, (end - start + 1)/sizeof(char));
      }
      llvm::errs() << "Node: " << NodeName << ":" << Code << "\n";


### PR DESCRIPTION
Clang does not support the getBeginLoc and getEndLoc functions anymore. Also, some of the clang headers use c++14/17 features, so the CMake needed to be updated to compile.

Compiled on Ubuntu 20.04